### PR TITLE
Added libstdc++ to the link line the -fjit option produces

### DIFF
--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -1247,6 +1247,7 @@ void tools::AddJITRunTimeLibs(const ToolChain &TC, const Driver &D,
     CmdArgs.push_back("-lclangParse");
     CmdArgs.push_back("-lclangSema");
     CmdArgs.push_back("-lclangSerialization");
+    CmdArgs.push_back("-lstdc++");
 
     AddFromLC("--libs");
     AddFromLC("--system-libs");


### PR DESCRIPTION
I'm not sure whether we want to add -lstdc++ or something more clever to handle people who use libc++, but this fix allows me to build Kripke with a stock build of this compiler using CMake