### PR TITLE
Fix module optimization

### DIFF
--- a/clang/lib/CodeGen/JIT.cpp
+++ b/clang/lib/CodeGen/JIT.cpp
@@ -502,10 +502,6 @@ public:
         fatal();
     }
 
-    EmitBackendOutput(Diags, HeaderSearchOpts, CodeGenOpts, TargetOpts,
-                      LangOpts, C.getTargetInfo().getDataLayout(),
-                      getModule(), Action,
-                      llvm::make_unique<llvm::buffer_ostream>(*AsmOutStream));
   }
 
   void HandleTagDeclDefinition(TagDecl *D) override {
@@ -526,6 +522,13 @@ public:
 
   void HandleVTable(CXXRecordDecl *RD) override {
     Gen->HandleVTable(RD);
+  }
+
+  void EmitOptimized() {
+    EmitBackendOutput(Diags, HeaderSearchOpts, CodeGenOpts, TargetOpts,
+                      LangOpts, Context->getTargetInfo().getDataLayout(),
+                      getModule(), Action,
+                      llvm::make_unique<llvm::buffer_ostream>(*AsmOutStream));
   }
 };
 
@@ -1397,6 +1400,7 @@ struct CompilerData {
 
     if (DevCD) {
       DevCD->Consumer->HandleTranslationUnit(*DevCD->Ctx);
+      DevCD->Consumer->EmitOptimized();
 
       // We have now created the PTX output, but what we really need as a
       // fatbin that the CUDA runtime will recognize.
@@ -1518,6 +1522,7 @@ struct CompilerData {
       DevCD->DevAsm.clear();
     }
 
+    // Finalize translation unit. No optimization yet.
     Consumer->HandleTranslationUnit(*Ctx);
 
     // First, mark everything we've newly generated with external linkage. When
@@ -1550,9 +1555,6 @@ struct CompilerData {
         GO->setComdat(nullptr);
     }
 
-    std::unique_ptr<llvm::Module> ToRunMod =
-      llvm::CloneModule(*Consumer->getModule());
-
     // Here we link our previous cache of definitions, etc. into this module.
     // This includes all of our previously-generated functions (marked as
     // available externally). We prefer our previously-generated versions to
@@ -1564,7 +1566,7 @@ struct CompilerData {
     // number), and these from previously-generated code will conflict with the
     // names chosen for string literals in this module.
 
-    for (auto &GV : ToRunMod->global_values()) {
+    for (auto &GV : Consumer->getModule()->global_values()) {
       if (!IsLocalUnnamedConst(GV) && !GV.getName().startswith("__cuda_"))
         continue;
 
@@ -1588,7 +1590,7 @@ struct CompilerData {
     // the base part of the module (as they specifically initialize variables,
     // etc. that we just generated).
 
-    for (auto &F : ToRunMod->functions()) {
+    for (auto &F : Consumer->getModule()->functions()) {
       // FIXME: This likely covers the set of TU-local init/deinit functions
       // that can't be shared with the base module. There should be a better
       // way to do this (e.g., we could record all functions that
@@ -1615,9 +1617,16 @@ struct CompilerData {
       F.setName(UniqueName);
     }
 
-    if (Linker::linkModules(*ToRunMod, llvm::CloneModule(*RunningMod),
+    if (Linker::linkModules(*Consumer->getModule(), llvm::CloneModule(*RunningMod),
                             Linker::Flags::OverrideFromSrc))
       fatal();
+
+    // Optimize the merged module, containing both the newly generated IR as well as
+    // previously emitted code marked available_externally.
+    Consumer->EmitOptimized();
+
+    std::unique_ptr<llvm::Module> ToRunMod =
+        llvm::CloneModule(*Consumer->getModule());
 
     CJ->addModule(std::move(ToRunMod));
 
@@ -1722,7 +1731,7 @@ struct InstMapInfo {
 
     return (unsigned) h;
   }
-  
+
   static unsigned getHashValue(const ThisInstInfo &TII) {
     using llvm::hash_code;
     using llvm::hash_combine;

--- a/clang/lib/CodeGen/JIT.cpp
+++ b/clang/lib/CodeGen/JIT.cpp
@@ -1650,8 +1650,9 @@ struct CompilerData {
           GV.setLinkage(llvm::GlobalValue::AvailableExternallyLinkage);
       }
 
+    // OverrideFromSrc is needed here too, otherwise globals marked available_externally are not considered.
     if (Linker::linkModules(*RunningMod, Consumer->takeModule(),
-                            Linker::Flags::None))
+                            Linker::Flags::OverrideFromSrc))
       fatal();
 
     Consumer->Initialize(*Ctx);


### PR DESCRIPTION
This pull request fixes two issues in the IR generation for JIT functions:

Previously, optimization of new code was done before merging the externally available definitions. Optimization (of host code) is now explicitly invoked by calling `Consumer->EmitOptimized()` right before adding the module to the JIT engine. This reordering enables inlining of existing code.

Some of the renaming of local globals and functions now happens before the module is cloned. Therefore, these changes will now also end up in `RunningMod`. If this turns out to be a problem, we will have to create an additional clone.

The second fix concerns the call to `linkModules` itself. By default, functions marked as `available_externally` are not merged into the target module. As a result, nothing was ever added to `RunningMod` and no previously generated instantiations could be reused.
Simply adding the `OverrideFromSrc` flag fixes the issue. I haven't noticed any unwanted side effects from adding this flag.

Disclaimer: I haven't tested this with CUDA. It should work fine though, as device code is handled exactly as before.